### PR TITLE
APP-99883 Update Uasurfer Repo to Handle Motorola Razr User Agent

### DIFF
--- a/cmd/uastats/main.go
+++ b/cmd/uastats/main.go
@@ -8,7 +8,7 @@ import (
 	"sort"
 	"text/tabwriter"
 
-	"github.com/avct/uasurfer"
+	"github.com/pendo-io/uasurfer"
 )
 
 func main() {

--- a/device.go
+++ b/device.go
@@ -17,7 +17,7 @@ func (u *UserAgent) evalDevice(ua string) {
 	case u.OS.Platform == PlatformiPad || u.OS.Platform == PlatformiPod || strings.Contains(ua, "tablet") || strings.Contains(ua, "kindle/") || strings.Contains(ua, "playbook"):
 		u.DeviceType = DeviceTablet
 
-	case u.OS.Platform == PlatformiPhone || u.OS.Platform == PlatformBlackberry || strings.Contains(ua, "phone"):
+	case u.OS.Platform == PlatformiPhone || u.OS.Platform == PlatformBlackberry || strings.Contains(ua, "phone") || strings.Contains(ua, "motorola razr"):
 		u.DeviceType = DevicePhone
 
 	// long list of smarttv and tv dongle identifiers

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/pendo-io/uasurfer
+
+go 1.21.8

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -254,6 +254,11 @@ var testUAVars = []struct {
 		UserAgent{
 			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{7, 5, 0}}, DevicePhone}},
 
+	// Motorola Phone
+	{"Mozilla/5.0 (Linux; Android 13; motorola razr 2023 Build/T2TVS33.45-83-2-3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.119 Mobile Safari/537.36",
+		UserAgent{
+			Browser{BrowserChrome, Version{122, 0, 6261}, Version{122, 0, 6261}}, OS{PlatformLinux, OSAndroid, Version{13, 0, 0}}, DevicePhone}},
+
 	// Kindle eReader
 	{"Mozilla/5.0 (Linux; U; en-US) AppleWebKit/528.5+ (KHTML, like Gecko, Safari/528.5+) Version/4.0 Kindle/3.0 (screen 600×800; rotate)",
 		UserAgent{


### PR DESCRIPTION
Dev Testing:
- [x] Unit test seems to be enough here. More testing to be done with app engine library update. 

Updating repo to include handle for Mororola Razr phone device.
 

![Screenshot 2024-04-08 at 9 05 46 AM](https://github.com/pendo-io/uasurfer/assets/68358371/9e9a17a8-27cd-447d-8ade-94b761bb0205)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pendo-io/uasurfer/12)
<!-- Reviewable:end -->
