### PR TITLE
Fix enum string values

### DIFF
--- a/const_string.go
+++ b/const_string.go
@@ -4,6 +4,19 @@ package uasurfer
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[DeviceUnknown-0]
+	_ = x[DeviceComputer-1]
+	_ = x[DeviceTablet-2]
+	_ = x[DevicePhone-3]
+	_ = x[DeviceConsole-4]
+	_ = x[DeviceWearable-5]
+	_ = x[DeviceTV-6]
+}
+
 const _DeviceType_name = "DeviceUnknownDeviceComputerDeviceTabletDevicePhoneDeviceConsoleDeviceWearableDeviceTV"
 
 var _DeviceType_index = [...]uint8{0, 13, 27, 39, 50, 63, 77, 85}
@@ -14,16 +27,77 @@ func (i DeviceType) String() string {
 	}
 	return _DeviceType_name[_DeviceType_index[i]:_DeviceType_index[i+1]]
 }
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[BrowserUnknown-0]
+	_ = x[BrowserChrome-1]
+	_ = x[BrowserIE-2]
+	_ = x[BrowserEdge-3]
+	_ = x[BrowserSafari-4]
+	_ = x[BrowserFirefox-5]
+	_ = x[BrowserAndroid-6]
+	_ = x[BrowserOpera-7]
+	_ = x[BrowserBlackberry-8]
+	_ = x[BrowserUCBrowser-9]
+	_ = x[BrowserSilk-10]
+	_ = x[BrowserNokia-11]
+	_ = x[BrowserNetFront-12]
+	_ = x[BrowserQQ-13]
+	_ = x[BrowserMaxthon-14]
+	_ = x[BrowserSogouExplorer-15]
+	_ = x[BrowserSpotify-16]
+	_ = x[BrowserWebkit-17]
+	_ = x[BrowserNintendo-18]
+	_ = x[BrowserSamsung-19]
+	_ = x[BrowserYandex-20]
+	_ = x[BrowserCocCoc-21]
+	_ = x[BrowserBot-22]
+	_ = x[BrowserAppleBot-23]
+	_ = x[BrowserBaiduBot-24]
+	_ = x[BrowserBingBot-25]
+	_ = x[BrowserDuckDuckGoBot-26]
+	_ = x[BrowserFacebookBot-27]
+	_ = x[BrowserGoogleBot-28]
+	_ = x[BrowserLinkedInBot-29]
+	_ = x[BrowserMsnBot-30]
+	_ = x[BrowserPingdomBot-31]
+	_ = x[BrowserTwitterBot-32]
+	_ = x[BrowserYandexBot-33]
+	_ = x[BrowserCocCocBot-34]
+	_ = x[BrowserYahooBot-35]
+}
 
-const _BrowserName_name = "BrowserUnknownBrowserChromeBrowserIEBrowserSafariBrowserFirefoxBrowserAndroidBrowserOperaBrowserBlackberryBrowserUCBrowserBrowserSilkBrowserNokiaBrowserNetFrontBrowserQQBrowserMaxthonBrowserSogouExplorerBrowserSpotifyBrowserNintendoBrowserSamsungBrowserYandexBrowserCocCocBrowserBotBrowserAppleBotBrowserBaiduBotBrowserBingBotBrowserDuckDuckGoBotBrowserFacebookBotBrowserGoogleBotBrowserLinkedInBotBrowserMsnBotBrowserPingdomBotBrowserTwitterBotBrowserYandexBotBrowserCocCocBotBrowserYahooBot"
+const _BrowserName_name = "BrowserUnknownBrowserChromeBrowserIEBrowserEdgeBrowserSafariBrowserFirefoxBrowserAndroidBrowserOperaBrowserBlackberryBrowserUCBrowserBrowserSilkBrowserNokiaBrowserNetFrontBrowserQQBrowserMaxthonBrowserSogouExplorerBrowserSpotifyBrowserWebkitBrowserNintendoBrowserSamsungBrowserYandexBrowserCocCocBrowserBotBrowserAppleBotBrowserBaiduBotBrowserBingBotBrowserDuckDuckGoBotBrowserFacebookBotBrowserGoogleBotBrowserLinkedInBotBrowserMsnBotBrowserPingdomBotBrowserTwitterBotBrowserYandexBotBrowserCocCocBotBrowserYahooBot"
 
-var _BrowserName_index = [...]uint16{0, 14, 27, 36, 49, 63, 77, 89, 106, 122, 133, 145, 160, 169, 183, 203, 217, 232, 246, 259, 272, 282, 297, 312, 326, 346, 364, 380, 398, 411, 428, 445, 461, 477, 492}
+var _BrowserName_index = [...]uint16{0, 14, 27, 36, 47, 60, 74, 88, 100, 117, 133, 144, 156, 171, 180, 194, 214, 228, 241, 256, 270, 283, 296, 306, 321, 336, 350, 370, 388, 404, 422, 435, 452, 469, 485, 501, 516}
 
 func (i BrowserName) String() string {
 	if i < 0 || i >= BrowserName(len(_BrowserName_index)-1) {
 		return "BrowserName(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _BrowserName_name[_BrowserName_index[i]:_BrowserName_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[OSUnknown-0]
+	_ = x[OSWindowsPhone-1]
+	_ = x[OSWindows-2]
+	_ = x[OSMacOSX-3]
+	_ = x[OSiOS-4]
+	_ = x[OSAndroid-5]
+	_ = x[OSBlackberry-6]
+	_ = x[OSChromeOS-7]
+	_ = x[OSKindle-8]
+	_ = x[OSWebOS-9]
+	_ = x[OSLinux-10]
+	_ = x[OSPlaystation-11]
+	_ = x[OSXbox-12]
+	_ = x[OSNintendo-13]
+	_ = x[OSBot-14]
 }
 
 const _OSName_name = "OSUnknownOSWindowsPhoneOSWindowsOSMacOSXOSiOSOSAndroidOSBlackberryOSChromeOSOSKindleOSWebOSOSLinuxOSPlaystationOSXboxOSNintendoOSBot"
@@ -35,6 +109,24 @@ func (i OSName) String() string {
 		return "OSName(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _OSName_name[_OSName_index[i]:_OSName_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[PlatformUnknown-0]
+	_ = x[PlatformWindows-1]
+	_ = x[PlatformMac-2]
+	_ = x[PlatformLinux-3]
+	_ = x[PlatformiPad-4]
+	_ = x[PlatformiPhone-5]
+	_ = x[PlatformiPod-6]
+	_ = x[PlatformBlackberry-7]
+	_ = x[PlatformWindowsPhone-8]
+	_ = x[PlatformPlaystation-9]
+	_ = x[PlatformXbox-10]
+	_ = x[PlatformNintendo-11]
+	_ = x[PlatformBot-12]
 }
 
 const _Platform_name = "PlatformUnknownPlatformWindowsPlatformMacPlatformLinuxPlatformiPadPlatformiPhonePlatformiPodPlatformBlackberryPlatformWindowsPhonePlatformPlaystationPlatformXboxPlatformNintendoPlatformBot"

--- a/uasurfer.go
+++ b/uasurfer.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 )
 
-//go:generate stringer -type=DeviceType,BrowserName,OSName,Platform -output=const_string.go
+//go:generate go run golang.org/x/tools/cmd/stringer@latest -type=DeviceType,BrowserName,OSName,Platform -output=const_string.go
 
 // DeviceType (int) returns a constant.
 type DeviceType int

--- a/uasurfer_test.go
+++ b/uasurfer_test.go
@@ -1,191 +1,312 @@
 package uasurfer
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 var testUAVars = []struct {
 	UA string
 	UserAgent
 }{
-	//Empty
-	{"",
-		UserAgent{}},
+	// Empty
+	{
+		"",
+		UserAgent{},
+	},
 
 	// Single char
-	{"a",
-		UserAgent{}},
+	{
+		"a",
+		UserAgent{},
+	},
 
 	// Some random string
-	{"some random string",
-		UserAgent{}},
+	{
+		"some random string",
+		UserAgent{},
+	},
 
 	// Potentially malformed ua
-	{")(",
-		UserAgent{}},
+	{
+		")(",
+		UserAgent{},
+	},
 
 	// iPhone
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/546.10 (KHTML, like Gecko) Version/6.0 Mobile/7E18WD Safari/8536.25",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/546.10 (KHTML, like Gecko) Version/6.0 Mobile/7E18WD Safari/8536.25",
 		UserAgent{
-			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{7, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{7, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4",
 		UserAgent{
-			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone}},
+			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone10,3; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4",
+	{
+		"Mozilla/5.0 (iPhone10,3; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4",
 		UserAgent{
-			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone}},
+			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone,
+		},
+	},
 
 	// iPad
-	{"Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
+	{
+		"Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
 		UserAgent{
-			Browser{BrowserSafari, Version{4, 0, 4}, Version{4, 0, 4}}, OS{PlatformiPad, OSiOS, Version{3, 2, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{4, 0, 4}, Version{4, 0, 4}}, OS{PlatformiPad, OSiOS, Version{3, 2, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 9_0 like Mac OS X) AppleWebKit/601.1.17 (KHTML, like Gecko) Version/8.0 Mobile/13A175 Safari/600.1.4",
 		UserAgent{
-			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPad, OSiOS, Version{9, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPad, OSiOS, Version{9, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.32 (KHTML, like Gecko) Version/10.0 Mobile/14A5261v Safari/602.1",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.32 (KHTML, like Gecko) Version/10.0 Mobile/14A5261v Safari/602.1",
 		UserAgent{
-			Browser{BrowserSafari, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{10, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{10, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// Chrome
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{43, 0, 2357}, Version{43, 0, 2357}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 4}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{43, 0, 2357}, Version{43, 0, 2357}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 4}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/534.48.3",
+	{
+		"Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_1_1 like Mac OS X; en) AppleWebKit/534.46.0 (KHTML, like Gecko) CriOS/19.0.1084.60 Mobile/9B206 Safari/534.48.3",
 		UserAgent{
-			Browser{BrowserChrome, Version{19, 0, 1084}, Version{19, 0, 1084}}, OS{PlatformiPhone, OSiOS, Version{5, 1, 1}}, DevicePhone}},
+			Browser{BrowserChrome, Version{19, 0, 1084}, Version{19, 0, 1084}}, OS{PlatformiPhone, OSiOS, Version{5, 1, 1}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 6.0; Nexus 5X Build/MDB08L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 6.0; Nexus 5X Build/MDB08L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{46, 0, 2490}, Version{46, 0, 2490}}, OS{PlatformLinux, OSAndroid, Version{6, 0, 0}}, DevicePhone}},
+			Browser{BrowserChrome, Version{46, 0, 2490}, Version{46, 0, 2490}}, OS{PlatformLinux, OSAndroid, Version{6, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// Chromium (Chrome)
-	{"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.19 (KHTML, like Gecko) Ubuntu/11.10 Chromium/18.0.1025.142 Chrome/18.0.1025.142 Safari/535.19",
+	{
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.19 (KHTML, like Gecko) Ubuntu/11.10 Chromium/18.0.1025.142 Chrome/18.0.1025.142 Safari/535.19",
 		UserAgent{
-			Browser{BrowserChrome, Version{18, 0, 1025}, Version{18, 0, 1025}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{18, 0, 1025}, Version{18, 0, 1025}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{45, 0, 2454}, Version{45, 0, 2454}}, OS{PlatformMac, OSMacOSX, Version{10, 11, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{45, 0, 2454}, Version{45, 0, 2454}}, OS{PlatformMac, OSMacOSX, Version{10, 11, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-G800F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-G800F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{28, 0, 1500}, Version{28, 0, 1500}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 2}}, DevicePhone}},
+			Browser{BrowserChrome, Version{28, 0, 1500}, Version{28, 0, 1500}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 2}}, DevicePhone,
+		},
+	},
 
 	// Safari
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/600.7.12 (KHTML, like Gecko) Version/8.0.7 Safari/600.7.12",
 		UserAgent{
-			Browser{BrowserSafari, Version{8, 0, 7}, Version{8, 0, 7}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 4}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{8, 0, 7}, Version{8, 0, 7}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 4}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_5; en-us) AppleWebKit/525.26.2 (KHTML, like Gecko) Version/3.2 Safari/525.26.12",
+	{
+		"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_5; en-us) AppleWebKit/525.26.2 (KHTML, like Gecko) Version/3.2 Safari/525.26.12",
 		UserAgent{
-			Browser{BrowserSafari, Version{3, 2, 0}, Version{3, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 5, 5}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{3, 2, 0}, Version{3, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 5, 5}}, DeviceComputer,
+		},
+	},
 
 	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12) AppleWebKit/602.1.32 (KHTML, like Gecko) Version/10.0 Safari/602.1.32", // macOS Sierra dev beta
 		UserAgent{
-			Browser{BrowserSafari, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 12, 0}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 12, 0}}, DeviceComputer,
+		}},
 
 	// Firefox
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4",
 		UserAgent{
-			Browser{BrowserFirefox, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 3, 0}}, DevicePhone}},
+			Browser{BrowserFirefox, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 3, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0",
+	{
+		"Mozilla/5.0 (Android 4.4; Tablet; rv:41.0) Gecko/41.0 Firefox/41.0",
 		UserAgent{
-			Browser{BrowserFirefox, Version{41, 0, 0}, Version{41, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 0}}, DeviceTablet}},
+			Browser{BrowserFirefox, Version{41, 0, 0}, Version{41, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (Android; Mobile; rv:40.0) Gecko/40.0 Firefox/40.0",
+	{
+		"Mozilla/5.0 (Android; Mobile; rv:40.0) Gecko/40.0 Firefox/40.0",
 		UserAgent{
-			Browser{BrowserFirefox, Version{40, 0, 0}, Version{40, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserFirefox, Version{40, 0, 0}, Version{40, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0",
+	{
+		"Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0",
 		UserAgent{
-			Browser{BrowserFirefox, Version{38, 0, 0}, Version{38, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{38, 0, 0}, Version{38, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; U; Android 4.4.3; de-de; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.47 like Chrome/37.0.2026.117 Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; U; Android 4.4.3; de-de; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.47 like Chrome/37.0.2026.117 Safari/537.36",
 		UserAgent{
-			Browser{BrowserSilk, Version{3, 47, 0}, Version{3, 47, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 3}}, DeviceTablet}},
+			Browser{BrowserSilk, Version{3, 47, 0}, Version{3, 47, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 3}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; U; en-us; KFJWI Build/IMM76D) AppleWebKit/535.19 (KHTML like Gecko) Silk/2.4 Safari/535.19 Silk-Acceleratedtrue",
+	{
+		"Mozilla/5.0 (Linux; U; en-us; KFJWI Build/IMM76D) AppleWebKit/535.19 (KHTML like Gecko) Silk/2.4 Safari/535.19 Silk-Acceleratedtrue",
 		UserAgent{
-			Browser{BrowserSilk, Version{2, 4, 0}, Version{2, 4, 0}}, OS{PlatformLinux, OSKindle, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSilk, Version{2, 4, 0}, Version{2, 4, 0}}, OS{PlatformLinux, OSKindle, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
 	// Opera
-	{"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36 OPR/18.0.1284.68",
+	{
+		"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36 OPR/18.0.1284.68",
 		UserAgent{
-			Browser{BrowserOpera, Version{18, 0, 1284}, Version{18, 0, 1284}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer}},
+			Browser{BrowserOpera, Version{18, 0, 1284}, Version{18, 0, 1284}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) OPiOS/10.2.0.93022 Mobile/12H143 Safari/9537.53",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 8_4 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) OPiOS/10.2.0.93022 Mobile/12H143 Safari/9537.53",
 		UserAgent{
-			Browser{BrowserOpera, Version{10, 2, 0}, Version{10, 2, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 4, 0}}, DevicePhone}},
+			Browser{BrowserOpera, Version{10, 2, 0}, Version{10, 2, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 4, 0}}, DevicePhone,
+		},
+	},
 
 	// Internet Explorer -- https://msdn.microsoft.com/en-us/library/hh869301(v=vs.85).aspx
-	{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.123",
+	{
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.123",
 		UserAgent{
-			Browser{BrowserEdge, Version{12, 123, 0}, Version{12, 123, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer}},
+			Browser{BrowserEdge, Version{12, 123, 0}, Version{12, 123, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)",
+	{
+		"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)",
 		UserAgent{
-			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko",
+	{
+		"Mozilla/5.0 (Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko",
 		UserAgent{
-			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/44.3.5 Mobile/15E148 Safari/605.1.15",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/44.3.5 Mobile/15E148 Safari/605.1.15",
 		UserAgent{
-			Browser{BrowserEdge, Version{12, 0, 0}, Version{12, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{12, 3, 1}}, DevicePhone}},
+			Browser{BrowserEdge, Version{12, 0, 0}, Version{12, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{12, 3, 1}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPad; CPU OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/44.3.2 Mobile/15E148 Safari/605.1.15",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 12_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 EdgiOS/44.3.2 Mobile/15E148 Safari/605.1.15",
 		UserAgent{
-			Browser{BrowserEdge, Version{12, 0, 0}, Version{12, 0, 0}}, OS{PlatformiPad, OSiOS, Version{12, 3, 1}}, DeviceTablet}},
+			Browser{BrowserEdge, Version{12, 0, 0}, Version{12, 0, 0}}, OS{PlatformiPad, OSiOS, Version{12, 3, 1}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 9; motorola one) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 EdgA/42.0.2.3728",
+	{
+		"Mozilla/5.0 (Linux; Android 9; motorola one) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 EdgA/42.0.2.3728",
 		UserAgent{
-			Browser{BrowserEdge, Version{42, 0, 2}, Version{42, 0, 2}}, OS{PlatformLinux, OSAndroid, Version{9, 0, 0}}, DevicePhone}},
+			Browser{BrowserEdge, Version{42, 0, 2}, Version{42, 0, 2}}, OS{PlatformLinux, OSAndroid, Version{9, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3800.0 Safari/537.36 Edg/76.0.172.0",
+	{
+		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3800.0 Safari/537.36 Edg/76.0.172.0",
 		UserAgent{
-			Browser{BrowserEdge, Version{76, 0, 172}, Version{76, 0, 172}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer}},
+			Browser{BrowserEdge, Version{76, 0, 172}, Version{76, 0, 172}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3803.0 Safari/537.36 Edg/76.0.176.0",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3803.0 Safari/537.36 Edg/76.0.176.0",
 		UserAgent{
-			Browser{BrowserEdge, Version{76, 0, 176}, Version{76, 0, 176}}, OS{PlatformMac, OSMacOSX, Version{10, 14, 5}}, DeviceComputer}},
+			Browser{BrowserEdge, Version{76, 0, 176}, Version{76, 0, 176}}, OS{PlatformMac, OSMacOSX, Version{10, 14, 5}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; DEVICE INFO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.123",
+	{
+		"Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; DEVICE INFO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Edge/12.123",
 		UserAgent{
-			Browser{BrowserEdge, Version{12, 123, 0}, Version{12, 123, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{10, 0, 0}}, DevicePhone}},
+			Browser{BrowserEdge, Version{12, 123, 0}, Version{12, 123, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{10, 0, 0}}, DevicePhone,
+		},
+	},
 
 	//{"Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 520) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537",
 	//	UserAgent{
 	//		Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 1, 0}}, DevicePhone}},
 
-	{"Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0; SV1; .NET CLR 1.1.4322; .NET CLR 1.0.3705; .NET CLR 2.0.50727)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0; SV1; .NET CLR 1.1.4322; .NET CLR 1.0.3705; .NET CLR 2.0.50727)",
 		UserAgent{
-			Browser{BrowserIE, Version{5, 0, 1}, Version{5, 0, 1}}, OS{PlatformWindows, OSWindows, Version{5, 0, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{5, 0, 1}, Version{5, 0, 1}}, OS{PlatformWindows, OSWindows, Version{5, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; GTB6.4; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 1.1.4322)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; GTB6.4; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 1.1.4322)",
 		UserAgent{
-			Browser{BrowserIE, Version{8, 0, 0}, Version{7, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{8, 0, 0}, Version{7, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)", //Windows Surface RT tablet
+	{"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch)", // Windows Surface RT tablet
 		UserAgent{
-			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceTablet}},
+			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceTablet,
+		}},
 
 	// UC Browser
-	{"Mozilla/5.0 (Linux; U; Android 2.3.4; en-US; MT11i Build/4.0.2.A.0.62) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31",
+	{
+		"Mozilla/5.0 (Linux; U; Android 2.3.4; en-US; MT11i Build/4.0.2.A.0.62) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31",
 		UserAgent{
-			Browser{BrowserUCBrowser, Version{9, 0, 1}, Version{9, 0, 1}}, OS{PlatformLinux, OSAndroid, Version{2, 3, 4}}, DevicePhone}},
+			Browser{BrowserUCBrowser, Version{9, 0, 1}, Version{9, 0, 1}}, OS{PlatformLinux, OSAndroid, Version{2, 3, 4}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; Micromax P255 Build/IMM76D) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.0.308 U3/0.8.0 Mobile Safari/534.31",
+	{
+		"Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; Micromax P255 Build/IMM76D) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.0.308 U3/0.8.0 Mobile Safari/534.31",
 		UserAgent{
-			Browser{BrowserUCBrowser, Version{9, 2, 0}, Version{9, 2, 0}}, OS{PlatformLinux, OSAndroid, Version{4, 0, 4}}, DevicePhone}},
+			Browser{BrowserUCBrowser, Version{9, 2, 0}, Version{9, 2, 0}}, OS{PlatformLinux, OSAndroid, Version{4, 0, 4}}, DevicePhone,
+		},
+	},
 
-	{"UCWEB/2.0 (Java; U; MIDP-2.0; en-US; MicromaxQ5) U2/1.0.0 UCBrowser/9.4.0.342 U2/1.0.0 Mobile",
+	{
+		"UCWEB/2.0 (Java; U; MIDP-2.0; en-US; MicromaxQ5) U2/1.0.0 UCBrowser/9.4.0.342 U2/1.0.0 Mobile",
 		UserAgent{
-			Browser{BrowserUCBrowser, Version{9, 4, 0}, Version{9, 4, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserUCBrowser, Version{9, 4, 0}, Version{9, 4, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// Nokia Browser
 	//{"Mozilla/5.0 (Series40; Nokia501/14.0.4/java_runtime_version=Nokia_Asha_1_2; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/4.0.0.0.45",
@@ -201,280 +322,437 @@ var testUAVars = []struct {
 	//		Browser{BrowserUnknown, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
 
 	// ChromeOS
-	{"Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5",
+	{
+		"Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5",
 		UserAgent{
-			Browser{BrowserChrome, Version{4, 0, 253}, Version{4, 0, 253}}, OS{PlatformLinux, OSChromeOS, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{4, 0, 253}, Version{4, 0, 253}}, OS{PlatformLinux, OSChromeOS, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
 	// iPod, iPod Touch
-	{"mozilla/5.0 (ipod touch; cpu iphone os 9_3_3 like mac os x) applewebkit/601.1.46 (khtml, like gecko) version/9.0 mobile/13g34 safari/601.1",
+	{
+		"mozilla/5.0 (ipod touch; cpu iphone os 9_3_3 like mac os x) applewebkit/601.1.46 (khtml, like gecko) version/9.0 mobile/13g34 safari/601.1",
 		UserAgent{
-			Browser{BrowserSafari, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformiPod, OSiOS, Version{9, 3, 3}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformiPod, OSiOS, Version{9, 3, 3}}, DeviceTablet,
+		},
+	},
 
-	{"mozilla/5.0 (ipod; cpu iphone os 6_1_6 like mac os x) applewebkit/536.26 (khtml, like gecko) version/6.0 mobile/10b500 safari/8536.25",
+	{
+		"mozilla/5.0 (ipod; cpu iphone os 6_1_6 like mac os x) applewebkit/536.26 (khtml, like gecko) version/6.0 mobile/10b500 safari/8536.25",
 		UserAgent{
-			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPod, OSiOS, Version{6, 1, 6}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPod, OSiOS, Version{6, 1, 6}}, DeviceTablet,
+		},
+	},
 
 	// WebOS
-	{"Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.0; U; de-DE) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.70 Safari/534.6 TouchPad/1.0",
+	{
+		"Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.0; U; de-DE) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.70 Safari/534.6 TouchPad/1.0",
 		UserAgent{
-			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (webOS/1.4.1.1; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.0",
+	{
+		"Mozilla/5.0 (webOS/1.4.1.1; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.0",
 		UserAgent{
-			Browser{BrowserSafari, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// Android WebView (Android <= 4.3)
 	//{"Mozilla/5.0 (Linux; U; Android 2.2; en-us; DROID2 GLOBAL Build/S273) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
 	//	UserAgent{
 	//		Browser{BrowserAndroid, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{2, 2, 0}}, DevicePhone}},
 
-	{"Mozilla/5.0 (Linux; U; Android 4.0.3; de-ch; HTC Sensation Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari53/4.30",
+	{
+		"Mozilla/5.0 (Linux; U; Android 4.0.3; de-ch; HTC Sensation Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari53/4.30",
 		UserAgent{
-			Browser{BrowserAndroid, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{4, 0, 3}}, DevicePhone}},
+			Browser{BrowserAndroid, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{4, 0, 3}}, DevicePhone,
+		},
+	},
 
 	// BlackBerry
-	{"Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+",
+	{
+		"Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{7, 2, 1}, Version{7, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserBlackberry, Version{7, 2, 1}, Version{7, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (BB10; Kbd) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.2.1.1925 Mobile Safari/537.35+",
+	{
+		"Mozilla/5.0 (BB10; Kbd) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.2.1.1925 Mobile Safari/537.35+",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{10, 2, 1}, Version{10, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserBlackberry, Version{10, 2, 1}, Version{10, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0) BlackBerry8703e/4.1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/104",
+	{
+		"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0) BlackBerry8703e/4.1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/104",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserBlackberry, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// Windows Phone
-	{"Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; ANZ941)",
+	{
+		"Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 625; ANZ941)",
 		UserAgent{
-			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 0, 0}}, DevicePhone}},
+			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 900)",
+	{
+		"Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 900)",
 		UserAgent{
-			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{7, 5, 0}}, DevicePhone}},
+			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{7, 5, 0}}, DevicePhone,
+		},
+	},
 
 	// Motorola Phone
-	{"Mozilla/5.0 (Linux; Android 13; motorola razr 2023 Build/T2TVS33.45-83-2-3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.119 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 13; motorola razr 2023 Build/T2TVS33.45-83-2-3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/122.0.6261.119 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{122, 0, 6261}, Version{122, 0, 6261}}, OS{PlatformLinux, OSAndroid, Version{13, 0, 0}}, DevicePhone}},
+			Browser{BrowserChrome, Version{122, 0, 6261}, Version{122, 0, 6261}}, OS{PlatformLinux, OSAndroid, Version{13, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// Kindle eReader
-	{"Mozilla/5.0 (Linux; U; en-US) AppleWebKit/528.5+ (KHTML, like Gecko, Safari/528.5+) Version/4.0 Kindle/3.0 (screen 600×800; rotate)",
+	{
+		"Mozilla/5.0 (Linux; U; en-US) AppleWebKit/528.5+ (KHTML, like Gecko, Safari/528.5+) Version/4.0 Kindle/3.0 (screen 600×800; rotate)",
 		UserAgent{
-			Browser{BrowserSafari, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSKindle, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSKindle, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (X11; U; Linux armv7l like Android; en-us) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/533.2+ Kindle/3.0+",
+	{
+		"Mozilla/5.0 (X11; U; Linux armv7l like Android; en-us) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/533.2+ Kindle/3.0+",
 		UserAgent{
-			Browser{BrowserSafari, Version{5, 0, 0}, Version{5, 0, 0}}, OS{PlatformLinux, OSKindle, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{5, 0, 0}, Version{5, 0, 0}}, OS{PlatformLinux, OSKindle, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
 	// Amazon Fire
-	{"Mozilla/5.0 (Linux; U; Android 4.4.3; de-de; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.67 like Chrome/39.0.2171.93 Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; U; Android 4.4.3; de-de; KFTHWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.67 like Chrome/39.0.2171.93 Safari/537.36",
 		UserAgent{
-			Browser{BrowserSilk, Version{3, 67, 0}, Version{3, 67, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 3}}, DeviceTablet}}, // Fire tablet
+			Browser{BrowserSilk, Version{3, 67, 0}, Version{3, 67, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 3}}, DeviceTablet,
+		},
+	}, // Fire tablet
 
-	{"Mozilla/5.0 (Linux; U; Android 4.2.2; en­us; KFTHWI Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.22 like Chrome/34.0.1847.137 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; U; Android 4.2.2; en­us; KFTHWI Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.22 like Chrome/34.0.1847.137 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserSilk, Version{3, 22, 0}, Version{3, 22, 0}}, OS{PlatformLinux, OSKindle, Version{4, 2, 2}}, DeviceTablet}}, // Fire tablet, but with "Mobile"
+			Browser{BrowserSilk, Version{3, 22, 0}, Version{3, 22, 0}}, OS{PlatformLinux, OSKindle, Version{4, 2, 2}}, DeviceTablet,
+		},
+	}, // Fire tablet, but with "Mobile"
 
-	{"Mozilla/5.0 (Linux; Android 4.4.4; SD4930UR Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/34.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/35.0.0.48.273;]",
+	{
+		"Mozilla/5.0 (Linux; Android 4.4.4; SD4930UR Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/34.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/35.0.0.48.273;]",
 		UserAgent{
-			Browser{BrowserChrome, Version{34, 0, 0}, Version{34, 0, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 4}}, DevicePhone}}, // Facebook app on Fire Phone
+			Browser{BrowserChrome, Version{34, 0, 0}, Version{34, 0, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 4}}, DevicePhone,
+		},
+	}, // Facebook app on Fire Phone
 
-	{"mozilla/5.0 (linux; android 4.4.3; kfthwi build/ktu84m) applewebkit/537.36 (khtml, like gecko) version/4.0 chrome/34.0.0.0 safari/537.36 [pinterest/android]",
+	{
+		"mozilla/5.0 (linux; android 4.4.3; kfthwi build/ktu84m) applewebkit/537.36 (khtml, like gecko) version/4.0 chrome/34.0.0.0 safari/537.36 [pinterest/android]",
 		UserAgent{
-			Browser{BrowserChrome, Version{34, 0, 0}, Version{34, 0, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 3}}, DeviceTablet}}, // Fire tablet running pinterest
+			Browser{BrowserChrome, Version{34, 0, 0}, Version{34, 0, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 3}}, DeviceTablet,
+		},
+	}, // Fire tablet running pinterest
 
-	{"Mozilla/5.0 (Linux; Android 4.4.4; SD4930UR Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.67 like Chrome/39.0.2171.93 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 4.4.4; SD4930UR Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.67 like Chrome/39.0.2171.93 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserSilk, Version{3, 67, 0}, Version{3, 67, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 4}}, DevicePhone}}, // Silk on Fire Phone
+			Browser{BrowserSilk, Version{3, 67, 0}, Version{3, 67, 0}}, OS{PlatformLinux, OSKindle, Version{4, 4, 4}}, DevicePhone,
+		},
+	}, // Silk on Fire Phone
 
 	// Nintendo
-	{"Opera/9.30 (Nintendo Wii; U; ; 2047-7; fr)",
+	{
+		"Opera/9.30 (Nintendo Wii; U; ; 2047-7; fr)",
 		UserAgent{
-			Browser{BrowserOpera, Version{9, 30, 0}, Version{9, 30, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole}},
+			Browser{BrowserOpera, Version{9, 30, 0}, Version{9, 30, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole,
+		},
+	},
 
-	{"Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US",
+	{
+		"Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US",
 		UserAgent{
-			Browser{BrowserNintendo, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole}},
+			Browser{BrowserNintendo, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole,
+		},
+	},
 
 	// Xbox
-	{"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)", //Xbox 360
+	{"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)", // Xbox 360
 		UserAgent{
-			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformXbox, OSXbox, Version{6, 1, 0}}, DeviceConsole}},
+			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformXbox, OSXbox, Version{6, 1, 0}}, DeviceConsole,
+		}},
 
 	// Playstation
 	//{"Mozilla/5.0 (PlayStation 4 4.50) AppleWebKit/601.2 (KHTML, like Gecko)",
 	//	UserAgent{
 	//		Browser{BrowserUnknown, Version{601, 2, 0}, Version{601, 2, 0}}, OS{PlatformPlaystation, OSPlaystation, Version{0, 0, 0}}, DeviceConsole}},
 
-	{"Mozilla/5.0 (Playstation Vita 1.61) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2",
+	{
+		"Mozilla/5.0 (Playstation Vita 1.61) AppleWebKit/531.22.8 (KHTML, like Gecko) Silk/3.2",
 		UserAgent{
-			Browser{BrowserSilk, Version{3, 2, 0}, Version{3, 2, 0}}, OS{PlatformPlaystation, OSPlaystation, Version{0, 0, 0}}, DeviceConsole}},
+			Browser{BrowserSilk, Version{3, 2, 0}, Version{3, 2, 0}}, OS{PlatformPlaystation, OSPlaystation, Version{0, 0, 0}}, DeviceConsole,
+		},
+	},
 
 	// Smart TVs and TV dongles
 	{"Mozilla/5.0 (CrKey armv7l 1.4.15250) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.0 Safari/537.36", // Chromecast
 		UserAgent{
-			Browser{BrowserChrome, Version{31, 0, 1650}, Version{31, 0, 1650}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserChrome, Version{31, 0, 1650}, Version{31, 0, 1650}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DeviceTV,
+		}},
 
 	{"Mozilla/5.0 (Linux; GoogleTV 3.2; VAP430 Build/MASTER) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Safari/534.24", // Google TV
 		UserAgent{
-			Browser{BrowserChrome, Version{11, 0, 696}, Version{11, 0, 696}}, OS{PlatformLinux, OSAndroid, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserChrome, Version{11, 0, 696}, Version{11, 0, 696}}, OS{PlatformLinux, OSAndroid, Version{0, 0, 0}}, DeviceTV,
+		}},
 
 	{"Mozilla/5.0 (Linux; Android 5.0; ADT-1 Build/LPX13D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36", // Android TV
 		UserAgent{
-			Browser{BrowserChrome, Version{40, 0, 2214}, Version{40, 0, 2214}}, OS{PlatformLinux, OSAndroid, Version{5, 0, 0}}, DeviceTV}},
+			Browser{BrowserChrome, Version{40, 0, 2214}, Version{40, 0, 2214}}, OS{PlatformLinux, OSAndroid, Version{5, 0, 0}}, DeviceTV,
+		}},
 
 	{"Mozilla/5.0 (Linux; Android 4.2.2; AFTB Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.173 Mobile Safari/537.22", // Amazon Fire
 		UserAgent{
-			Browser{BrowserChrome, Version{25, 0, 1364}, Version{25, 0, 1364}}, OS{PlatformLinux, OSAndroid, Version{4, 2, 2}}, DeviceTV}},
+			Browser{BrowserChrome, Version{25, 0, 1364}, Version{25, 0, 1364}}, OS{PlatformLinux, OSAndroid, Version{4, 2, 2}}, DeviceTV,
+		}},
 
 	{"Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ LG Browser/6.00.00(+mouse+3D+SCREEN+TUNER; LGE; GLOBAL-PLAT5; 03.07.01; 0x00000001;); LG NetCast.TV-2013/03.17.01 (LG, GLOBAL-PLAT4, wired)", // LG TV
 		UserAgent{
-			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV,
+		}},
 
 	{"Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.0 Chrome/23.0.1271.97 Safari/537.11", // Panasonic Viera
 		UserAgent{
-			Browser{BrowserChrome, Version{23, 0, 1271}, Version{23, 0, 1271}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserChrome, Version{23, 0, 1271}, Version{23, 0, 1271}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV,
+		}},
 
 	{"Mozilla/5.0 (DTV) AppleWebKit/531.2+ (KHTML, like Gecko) Espial/6.1.5 AQUOSBrowser/2.0 (US01DTV;V;0001;0001)", // Sharp Aquos
 		UserAgent{
-			Browser{BrowserWebkit, Version{531, 2, 0}, Version{531, 2, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserWebkit, Version{531, 2, 0}, Version{531, 2, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DeviceTV,
+		}},
 
 	{"Roku/DVP-5.2 (025.02E03197A)", // Roku
 		UserAgent{
-			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DeviceTV,
+		}},
 
 	{"mozilla/5.0 (smart-tv; linux; tizen 2.3) applewebkit/538.1 (khtml, like gecko) samsungbrowser/1.0 tv safari/538.1", // Samsung SmartTV
 		UserAgent{
-			Browser{BrowserSamsung, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserSamsung, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV,
+		}},
 
-	{"mozilla/5.0 (linux; u) applewebkit/537.36 (khtml, like gecko) version/4.0 mobile safari/537.36 smarttv/6.0 (netcast)",
+	{
+		"mozilla/5.0 (linux; u) applewebkit/537.36 (khtml, like gecko) version/4.0 mobile safari/537.36 smarttv/6.0 (netcast)",
 		UserAgent{
-			Browser{BrowserSafari, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV}},
+			Browser{BrowserSafari, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceTV,
+		},
+	},
 
 	// Google search app (GSA) for iOS -- it's Safari in disguise as of v6
-	{"Mozilla/5.0 (iPad; CPU OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) GSA/6.0.51363 Mobile/12F69 Safari/600.1.4",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) GSA/6.0.51363 Mobile/12F69 Safari/600.1.4",
 		UserAgent{
-			Browser{BrowserSafari, Version{8, 3, 0}, Version{8, 3, 0}}, OS{PlatformiPad, OSiOS, Version{8, 3, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{8, 3, 0}, Version{8, 3, 0}}, OS{PlatformiPad, OSiOS, Version{8, 3, 0}}, DeviceTablet,
+		},
+	},
 
 	// Spotify (applicable for advertising applications)
-	{"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.9.133 Safari/537.36",
+	{
+		"Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.9.133 Safari/537.36",
 		UserAgent{
-			Browser{BrowserSpotify, Version{1, 0, 9}, Version{1, 0, 9}}, OS{PlatformWindows, OSWindows, Version{5, 1, 0}}, DeviceComputer}},
+			Browser{BrowserSpotify, Version{1, 0, 9}, Version{1, 0, 9}}, OS{PlatformWindows, OSWindows, Version{5, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.9.133 Safari/537.36",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/537.36 (KHTML, like Gecko) Spotify/1.0.9.133 Safari/537.36",
 		UserAgent{
-			Browser{BrowserSpotify, Version{1, 0, 9}, Version{1, 0, 9}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 2}}, DeviceComputer}},
+			Browser{BrowserSpotify, Version{1, 0, 9}, Version{1, 0, 9}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 2}}, DeviceComputer,
+		},
+	},
 
 	// OCSP fetchers
-	{"Microsoft-CryptoAPI/10.0",
+	{
+		"Microsoft-CryptoAPI/10.0",
 		UserAgent{
-			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformWindows, OSUnknown, Version{0, 0, 0}}, DeviceComputer}},
-	{"trustd (unknown version) CFNetwork/811.7.2 Darwin/16.7.0 (x86_64)",
+			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformWindows, OSUnknown, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
+	{
+		"trustd (unknown version) CFNetwork/811.7.2 Darwin/16.7.0 (x86_64)",
 		UserAgent{
-			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformMac, OSUnknown, Version{0, 0, 0}}, DeviceComputer}},
-	{"ocspd (unknown version) CFNetwork/520.5.3 Darwin/11.4.2 (x86_64)(MacBookAir5%2C2)",
+			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformMac, OSUnknown, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
+	{
+		"ocspd (unknown version) CFNetwork/520.5.3 Darwin/11.4.2 (x86_64)(MacBookAir5%2C2)",
 		UserAgent{
-			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformMac, OSUnknown, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformMac, OSUnknown, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 	// Bots
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1; +http://www.apple.com/go/applebot)",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_1) AppleWebKit/600.2.5 (KHTML, like Gecko) Version/8.0.2 Safari/600.2.5 (Applebot/0.1; +http://www.apple.com/go/applebot)",
 		UserAgent{
-			Browser{BrowserAppleBot, Version{8, 0, 2}, Version{8, 0, 2}}, OS{PlatformBot, OSBot, Version{10, 10, 1}}, DeviceComputer}},
+			Browser{BrowserAppleBot, Version{8, 0, 2}, Version{8, 0, 2}}, OS{PlatformBot, OSBot, Version{10, 10, 1}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)",
+	{
+		"Mozilla/5.0 (compatible; Baiduspider/2.0; +http://www.baidu.com/search/spider.html)",
 		UserAgent{
-			Browser{BrowserBaiduBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserBaiduBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
+	{
+		"Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)",
 		UserAgent{
-			Browser{BrowserBingBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserBingBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)",
+	{
+		"DuckDuckBot/1.0; (+http://duckduckgo.com/duckduckbot.html)",
 		UserAgent{
-			Browser{BrowserDuckDuckGoBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserDuckDuckGoBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
+	{
+		"facebookexternalhit/1.1 (+http://www.facebook.com/externalhit_uatext.php)",
 		UserAgent{
-			Browser{BrowserFacebookBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserFacebookBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Facebot/1.0",
+	{
+		"Facebot/1.0",
 		UserAgent{
-			Browser{BrowserFacebookBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserFacebookBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+	{
+		"Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
 		UserAgent{
-			Browser{BrowserGoogleBot, Version{2, 1, 0}, Version{2, 1, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserGoogleBot, Version{2, 1, 0}, Version{2, 1, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)",
+	{
+		"LinkedInBot/1.0 (compatible; Mozilla/5.0; Jakarta Commons-HttpClient/3.1 +http://www.linkedin.com)",
 		UserAgent{
-			Browser{BrowserLinkedInBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserLinkedInBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"msnbot/2.0b (+http://search.msn.com/msnbot.htm)",
+	{
+		"msnbot/2.0b (+http://search.msn.com/msnbot.htm)",
 		UserAgent{
-			Browser{BrowserMsnBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserMsnBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
+	{
+		"Pingdom.com_bot_version_1.4_(http://www.pingdom.com/)",
 		UserAgent{
-			Browser{BrowserPingdomBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserPingdomBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Twitterbot/1.0",
+	{
+		"Twitterbot/1.0",
 		UserAgent{
-			Browser{BrowserTwitterBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserTwitterBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)",
+	{
+		"Mozilla/5.0 (compatible; YandexBot/3.0; +http://yandex.com/bots)",
 		UserAgent{
-			Browser{BrowserYandexBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserYandexBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)",
+	{
+		"Mozilla/5.0 (compatible; Yahoo! Slurp; http://help.yahoo.com/help/us/ysearch/slurp)",
 		UserAgent{
-			Browser{BrowserYahooBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserYahooBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"{UA:Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)}, ua: &{Browser:{Name:BrowserGoogleBot Version:{Major:0 Minor:0 Patch:0}} OS:{Platform:PlatformBot Name:OSBot Version:{Major:6 Minor:0 Patch:1}} DeviceType:DeviceComputer}",
+	{
+		"{UA:Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)}, ua: &{Browser:{Name:BrowserGoogleBot Version:{Major:0 Minor:0 Patch:0}} OS:{Platform:PlatformBot Name:OSBot Version:{Major:6 Minor:0 Patch:1}} DeviceType:DeviceComputer}",
 		UserAgent{
-			Browser{BrowserGoogleBot, Version{2, 1, 0}, Version{2, 1, 0}}, OS{PlatformBot, OSBot, Version{6, 0, 1}}, DeviceComputer}},
+			Browser{BrowserGoogleBot, Version{2, 1, 0}, Version{2, 1, 0}}, OS{PlatformBot, OSBot, Version{6, 0, 1}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)",
 		UserAgent{
-			Browser{BrowserGoogleBot, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformBot, OSBot, Version{6, 0, 0}}, DeviceComputer}},
+			Browser{BrowserGoogleBot, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformBot, OSBot, Version{6, 0, 0}}, DeviceComputer,
+		},
+	},
 
 	//{"mozilla/5.0 (unknown; linux x86_64) applewebkit/538.1 (khtml, like gecko) phantomjs/2.1.1 safari/538.1",
 	//	UserAgent{
 	//		Browser{BrowserBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
 
 	// Unknown or partially handled
-	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.1b3pre) Gecko/20090223 SeaMonkey/2.0a3", //Seamonkey (~FF)
+	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.1b3pre) Gecko/20090223 SeaMonkey/2.0a3", // Seamonkey (~FF)
 		UserAgent{
-			Browser{BrowserFirefox, Version{1, 9, 1}, Version{1, 9, 1}}, OS{PlatformMac, OSMacOSX, Version{10, 4, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{1, 9, 1}, Version{1, 9, 1}}, OS{PlatformMac, OSMacOSX, Version{10, 4, 0}}, DeviceComputer,
+		}},
 
 	//{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en; rv:1.9.0.8pre) Gecko/2009022800 Camino/2.0b3pre", //Camino (~FF)
 	//	UserAgent{
 	//		Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 5, 0}}, DeviceComputer}},
 
-	{"Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0", //firefox OS
+	{"Mozilla/5.0 (Mobile; rv:26.0) Gecko/26.0 Firefox/26.0", // firefox OS
 		UserAgent{
-			Browser{BrowserFirefox, Version{26, 0, 0}, Version{26, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserFirefox, Version{26, 0, 0}, Version{26, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		}},
 
-	{"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.45 Safari/535.19", //chrome for android having requested desktop site
+	{"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.45 Safari/535.19", // chrome for android having requested desktop site
 		UserAgent{
-			Browser{BrowserChrome, Version{18, 0, 1025}, Version{18, 0, 1025}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{18, 0, 1025}, Version{18, 0, 1025}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer,
+		}},
 
-	{"Opera/9.80 (S60; SymbOS; Opera Mobi/352; U; de) Presto/2.4.15 Version/10.00",
+	{
+		"Opera/9.80 (S60; SymbOS; Opera Mobi/352; U; de) Presto/2.4.15 Version/10.00",
 		UserAgent{
-			Browser{BrowserOpera, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserOpera, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// BrowserQQ
-	{"Mozilla/5.0 (Windows NT 6.2; WOW64; Trident/7.0; Touch; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; InfoPath.3; Tablet PC 2.0; QQBrowser/7.6.21433.400; rv:11.0) like Gecko",
+	{
+		"Mozilla/5.0 (Windows NT 6.2; WOW64; Trident/7.0; Touch; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; InfoPath.3; Tablet PC 2.0; QQBrowser/7.6.21433.400; rv:11.0) like Gecko",
 		UserAgent{
-			Browser{BrowserQQ, Version{7, 6, 21433}, Version{7, 6, 21433}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceTablet}},
+			Browser{BrowserQQ, Version{7, 6, 21433}, Version{7, 6, 21433}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36 QQBrowser/9.0.2191.400",
+	{
+		"Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.124 Safari/537.36 QQBrowser/9.0.2191.400",
 		UserAgent{
-			Browser{BrowserQQ, Version{9, 0, 2191}, Version{9, 0, 2191}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer}},
+			Browser{BrowserQQ, Version{9, 0, 2191}, Version{9, 0, 2191}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"mozilla/5.0 (iphone; cpu iphone os 8_1_2 like mac os x) applewebkit/600.1.4 (khtml, like gecko) mobile/12b440 qq/5.3.0.319 nettype/wifi mem/205",
+	{
+		"mozilla/5.0 (iphone; cpu iphone os 8_1_2 like mac os x) applewebkit/600.1.4 (khtml, like gecko) mobile/12b440 qq/5.3.0.319 nettype/wifi mem/205",
 		UserAgent{
-			Browser{BrowserQQ, Version{5, 3, 0}, Version{5, 3, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 1, 2}}, DevicePhone}},
+			Browser{BrowserQQ, Version{5, 3, 0}, Version{5, 3, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 1, 2}}, DevicePhone,
+		},
+	},
 
 	// ANDROID TESTS
 
@@ -603,393 +881,657 @@ var testUAVars = []struct {
 	//	UserAgent{
 	//		Browser{BrowserAndroid, Version{4, 0, 0}, Version{4, 0, 0}}, OS{PlatformLinux, OSAndroid, Version{4, 2, 0}}, DevicePhone}},
 
-	{"Mozilla/5.0 (Linux; Android 4.3; Nexus 7 Build/JWR66D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.111 Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 4.3; Nexus 7 Build/JWR66D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.111 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{27, 0, 1453}, Version{27, 0, 1453}}, OS{PlatformLinux, OSAndroid, Version{4, 3, 0}}, DeviceTablet}},
+			Browser{BrowserChrome, Version{27, 0, 1453}, Version{27, 0, 1453}}, OS{PlatformLinux, OSAndroid, Version{4, 3, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 4.4; Nexus 7 Build/KOT24) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.105 Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 4.4; Nexus 7 Build/KOT24) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.105 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{30, 0, 1599}, Version{30, 0, 1599}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 0}}, DeviceTablet}},
+			Browser{BrowserChrome, Version{30, 0, 1599}, Version{30, 0, 1599}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 4.4; Nexus 4 Build/KRT16E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.105 Mobile Safari",
+	{
+		"Mozilla/5.0 (Linux; Android 4.4; Nexus 4 Build/KRT16E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.105 Mobile Safari",
 		UserAgent{
-			Browser{BrowserChrome, Version{30, 0, 1599}, Version{30, 0, 1599}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 0}}, DevicePhone}},
+			Browser{BrowserChrome, Version{30, 0, 1599}, Version{30, 0, 1599}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 6.0.1; SM-G930V Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 6.0.1; SM-G930V Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{52, 0, 2743}, Version{52, 0, 2743}}, OS{PlatformLinux, OSAndroid, Version{6, 0, 1}}, DevicePhone}},
+			Browser{BrowserChrome, Version{52, 0, 2743}, Version{52, 0, 2743}}, OS{PlatformLinux, OSAndroid, Version{6, 0, 1}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 7.0; Nexus 5X Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 7.0; Nexus 5X Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{52, 0, 2743}, Version{52, 0, 2743}}, OS{PlatformLinux, OSAndroid, Version{7, 0, 0}}, DevicePhone}},
+			Browser{BrowserChrome, Version{52, 0, 2743}, Version{52, 0, 2743}}, OS{PlatformLinux, OSAndroid, Version{7, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 7.0; Nexus 6P Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 Mobile Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 7.0; Nexus 6P Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 Mobile Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{52, 0, 2743}, Version{52, 0, 2743}}, OS{PlatformLinux, OSAndroid, Version{7, 0, 0}}, DevicePhone}},
+			Browser{BrowserChrome, Version{52, 0, 2743}, Version{52, 0, 2743}}, OS{PlatformLinux, OSAndroid, Version{7, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// BLACKBERRY TESTS
 
-	{"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0) BlackBerry8703e/4.1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/104",
+	{
+		"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0) BlackBerry8703e/4.1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/104",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserBlackberry, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.1.0.4633 Mobile Safari/537.10+",
+	{
+		"Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.1.0.4633 Mobile Safari/537.10+",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{10, 1, 0}, Version{10, 1, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserBlackberry, Version{10, 1, 0}, Version{10, 1, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (BB10; Kbd) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.2.1.1925 Mobile Safari/537.35+",
+	{
+		"Mozilla/5.0 (BB10; Kbd) AppleWebKit/537.35+ (KHTML, like Gecko) Version/10.2.1.1925 Mobile Safari/537.35+",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{10, 2, 1}, Version{10, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserBlackberry, Version{10, 2, 1}, Version{10, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.11 (KHTML, like Gecko) Version/7.1.0.7 Safari/534.11",
+	{
+		"Mozilla/5.0 (PlayBook; U; RIM Tablet OS 1.0.0; en-US) AppleWebKit/534.11 (KHTML, like Gecko) Version/7.1.0.7 Safari/534.11",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{7, 1, 0}, Version{7, 1, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserBlackberry, Version{7, 1, 0}, Version{7, 1, 0}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+",
+	{
+		"Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+",
 		UserAgent{
-			Browser{BrowserBlackberry, Version{7, 2, 1}, Version{7, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserBlackberry, Version{7, 2, 1}, Version{7, 2, 1}}, OS{PlatformBlackberry, OSBlackberry, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5",
+	{
+		"Mozilla/5.0 (X11; U; CrOS i686 9.10.0; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.253.0 Safari/532.5",
 		UserAgent{
-			Browser{BrowserChrome, Version{4, 0, 253}, Version{4, 0, 253}}, OS{PlatformLinux, OSChromeOS, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{4, 0, 253}, Version{4, 0, 253}}, OS{PlatformLinux, OSChromeOS, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (X11; CrOS armv7l 5500.100.6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.120 Safari/537.36",
+	{
+		"Mozilla/5.0 (X11; CrOS armv7l 5500.100.6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.120 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{34, 0, 1847}, Version{34, 0, 1847}}, OS{PlatformLinux, OSChromeOS, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{34, 0, 1847}, Version{34, 0, 1847}}, OS{PlatformLinux, OSChromeOS, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 	// REALLY OLD COMMENTED OUT TESTS
-	{"Mozilla/5.0 (Mobile; rv:14.0) Gecko/14.0 Firefox/14.0",
+	{
+		"Mozilla/5.0 (Mobile; rv:14.0) Gecko/14.0 Firefox/14.0",
 		UserAgent{
-			Browser{BrowserFirefox, Version{14, 0, 0}, Version{14, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserFirefox, Version{14, 0, 0}, Version{14, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Mobile; rv:17.0) Gecko/14.0 Firefox/17.0",
+	{
+		"Mozilla/5.0 (Mobile; rv:17.0) Gecko/14.0 Firefox/17.0",
 		UserAgent{
-			Browser{BrowserFirefox, Version{17, 0, 0}, Version{17, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserFirefox, Version{17, 0, 0}, Version{17, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Mobile; rv:18.1) Gecko/18.1 Firefox/18.1",
+	{
+		"Mozilla/5.0 (Mobile; rv:18.1) Gecko/18.1 Firefox/18.1",
 		UserAgent{
-			Browser{BrowserFirefox, Version{18, 1, 0}, Version{18, 1, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserFirefox, Version{18, 1, 0}, Version{18, 1, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Mobile; LG-D300; rv:18.1) Gecko/18.1 Firefox/18.1",
+	{
+		"Mozilla/5.0 (Mobile; LG-D300; rv:18.1) Gecko/18.1 Firefox/18.1",
 		UserAgent{
-			Browser{BrowserFirefox, Version{18, 1, 0}, Version{18, 1, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserFirefox, Version{18, 1, 0}, Version{18, 1, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
+	{
+		"Mozilla/5.0(iPad; U; CPU iPhone OS 3_2 like Mac OS X; en-us) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B314 Safari/531.21.10",
 		UserAgent{
-			Browser{BrowserSafari, Version{4, 0, 4}, Version{4, 0, 4}}, OS{PlatformiPad, OSiOS, Version{3, 2, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{4, 0, 4}, Version{4, 0, 4}}, OS{PlatformiPad, OSiOS, Version{3, 2, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7",
+	{
+		"Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_0 like Mac OS X; en-us) AppleWebKit/532.9 (KHTML, like Gecko) Version/4.0.5 Mobile/8A293 Safari/6531.22.7",
 		UserAgent{
-			Browser{BrowserSafari, Version{4, 0, 5}, Version{4, 0, 5}}, OS{PlatformiPhone, OSiOS, Version{4, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{4, 0, 5}, Version{4, 0, 5}}, OS{PlatformiPhone, OSiOS, Version{4, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
 		UserAgent{
-			Browser{BrowserSafari, Version{5, 1, 0}, Version{5, 1, 0}}, OS{PlatformiPhone, OSiOS, Version{5, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{5, 1, 0}, Version{5, 1, 0}}, OS{PlatformiPhone, OSiOS, Version{5, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 5_0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9A334 Safari/7534.48.3",
 		UserAgent{
-			Browser{BrowserSafari, Version{5, 1, 0}, Version{5, 1, 0}}, OS{PlatformiPad, OSiOS, Version{5, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{5, 1, 0}, Version{5, 1, 0}}, OS{PlatformiPad, OSiOS, Version{5, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25",
 		UserAgent{
-			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPad, OSiOS, Version{6, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPad, OSiOS, Version{6, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/546.10 (KHTML, like Gecko) Version/6.0 Mobile/7E18WD Safari/8536.25",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 7_0 like Mac OS X) AppleWebKit/546.10 (KHTML, like Gecko) Version/6.0 Mobile/7E18WD Safari/8536.25",
 		UserAgent{
-			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{7, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{7, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A465 Safari/9537.53",
 		UserAgent{
-			Browser{BrowserSafari, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformiPad, OSiOS, Version{7, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformiPad, OSiOS, Version{7, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPad; CPU OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 7_0_2 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11A501 Safari/9537.53",
 		UserAgent{
-			Browser{BrowserSafari, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformiPad, OSiOS, Version{7, 0, 2}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformiPad, OSiOS, Version{7, 0, 2}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 [FBAN/FBIOS;FBAV/86.0.0.48.52;FBBV/53842252;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/10.2.1;FBSS/2;FBCR/Verizon;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 [FBAN/FBIOS;FBAV/86.0.0.48.52;FBBV/53842252;FBDV/iPhone9,1;FBMD/iPhone;FBSN/iOS;FBSV/10.2.1;FBSS/2;FBCR/Verizon;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]",
 		UserAgent{
-			Browser{BrowserWebkit, Version{602, 4, 6}, Version{602, 4, 6}}, OS{PlatformiPhone, OSiOS, Version{10, 2, 1}}, DevicePhone}},
+			Browser{BrowserWebkit, Version{602, 4, 6}, Version{602, 4, 6}}, OS{PlatformiPhone, OSiOS, Version{10, 2, 1}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/12A4265u",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/12A4265u",
 		UserAgent{
-			Browser{BrowserWebkit, Version{538, 34, 9}, Version{538, 34, 9}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 0}}, DevicePhone}},
+			Browser{BrowserWebkit, Version{538, 34, 9}, Version{538, 34, 9}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (iPad; CPU OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/12A4265u",
+	{
+		"Mozilla/5.0 (iPad; CPU OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/12A4265u",
 		UserAgent{
-			Browser{BrowserWebkit, Version{538, 34, 9}, Version{538, 34, 9}}, OS{PlatformiPad, OSiOS, Version{8, 0, 0}}, DeviceTablet}},
+			Browser{BrowserWebkit, Version{538, 34, 9}, Version{538, 34, 9}}, OS{PlatformiPad, OSiOS, Version{8, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4",
+	{
+		"Mozilla/5.0 (iPhone; CPU iPhone OS 8_0_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Version/8.0 Mobile/12A405 Safari/600.1.4",
 		UserAgent{
-			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone}},
+			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformiPhone, OSiOS, Version{8, 0, 2}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (X11; U; Linux x86_64; en; rv:1.9.0.14) Gecko/20080528 Ubuntu/9.10 (karmic) Epiphany/2.22 Firefox/3.0",
+	{
+		"Mozilla/5.0 (X11; U; Linux x86_64; en; rv:1.9.0.14) Gecko/20080528 Ubuntu/9.10 (karmic) Epiphany/2.22 Firefox/3.0",
 		UserAgent{
-			Browser{BrowserFirefox, Version{3, 0, 0}, Version{3, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{3, 0, 0}, Version{3, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (X11; U; Linux x86_64; zh-TW; rv:1.9.0.8) Gecko/2009032712 Ubuntu/8.04 (hardy) Firefox/3.0.8 GTB5",
+	{
+		"Mozilla/5.0 (X11; U; Linux x86_64; zh-TW; rv:1.9.0.8) Gecko/2009032712 Ubuntu/8.04 (hardy) Firefox/3.0.8 GTB5",
 		UserAgent{
-			Browser{BrowserFirefox, Version{3, 0, 8}, Version{3, 0, 8}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{3, 0, 8}, Version{3, 0, 8}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
 	//{"Mozilla/5.0 (compatible; Konqueror/3.5; Linux; x86_64) KHTML/3.5.5 (like Gecko) (Debian)",
 	//	UserAgent{
 	//		Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer}},
 
-	{"Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.1.5) Gecko/20091112 Iceweasel/3.5.5 (like Firefox/3.5.5; Debian-3.5.5-1)",
+	{
+		"Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.1.5) Gecko/20091112 Iceweasel/3.5.5 (like Firefox/3.5.5; Debian-3.5.5-1)",
 		UserAgent{
-			Browser{BrowserFirefox, Version{3, 5, 5}, Version{3, 5, 5}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{3, 5, 5}, Version{3, 5, 5}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
 	// TODO consider bot?
 	//{"Miro/2.0.4 (http://www.getmiro.com/; Darwin 10.3.0 i386)",
 	//	UserAgent{
 	//		Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{3, 0, 0}}, DeviceComputer}},
 
-	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.1b3pre) Gecko/20090223 SeaMonkey/2.0a3",
+	{
+		"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.4; en-US; rv:1.9.1b3pre) Gecko/20090223 SeaMonkey/2.0a3",
 		UserAgent{
-			Browser{BrowserFirefox, Version{1, 9, 1}, Version{1, 9, 1}}, OS{PlatformMac, OSMacOSX, Version{10, 4, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{1, 9, 1}, Version{1, 9, 1}}, OS{PlatformMac, OSMacOSX, Version{10, 4, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_5; en-us) AppleWebKit/525.26.2 (KHTML, like Gecko) Version/3.2 Safari/525.26.12",
+	{
+		"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_5; en-us) AppleWebKit/525.26.2 (KHTML, like Gecko) Version/3.2 Safari/525.26.12",
 		UserAgent{
-			Browser{BrowserSafari, Version{3, 2, 0}, Version{3, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 5, 5}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{3, 2, 0}, Version{3, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 5, 5}}, DeviceComputer,
+		},
+	},
 
 	//{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.5; en; rv:1.9.0.8pre) Gecko/2009022800 Camino/2.0b3pre",
 	//	UserAgent{
 	//		Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 5, 0}}, DeviceComputer}},
 
-	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_2; en-US) AppleWebKit/533.1 (KHTML, like Gecko) Chrome/5.0.329.0 Safari/533.1",
+	{
+		"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_2; en-US) AppleWebKit/533.1 (KHTML, like Gecko) Chrome/5.0.329.0 Safari/533.1",
 		UserAgent{
-			Browser{BrowserChrome, Version{5, 0, 329}, Version{5, 0, 329}}, OS{PlatformMac, OSMacOSX, Version{10, 6, 2}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{5, 0, 329}, Version{5, 0, 329}}, OS{PlatformMac, OSMacOSX, Version{10, 6, 2}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6 (.NET CLR 3.5.30729)",
+	{
+		"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6 (.NET CLR 3.5.30729)",
 		UserAgent{
-			Browser{BrowserFirefox, Version{3, 5, 6}, Version{3, 5, 6}}, OS{PlatformMac, OSMacOSX, Version{10, 6, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{3, 5, 6}, Version{3, 5, 6}}, OS{PlatformMac, OSMacOSX, Version{10, 6, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko) Version/5.1.2 Safari/534.52.7",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/534.52.7 (KHTML, like Gecko) Version/5.1.2 Safari/534.52.7",
 		UserAgent{
-			Browser{BrowserSafari, Version{5, 1, 2}, Version{5, 1, 2}}, OS{PlatformMac, OSMacOSX, Version{10, 7, 2}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{5, 1, 2}, Version{5, 1, 2}}, OS{PlatformMac, OSMacOSX, Version{10, 7, 2}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:9.0) Gecko/20111222 Thunderbird/9.0.1",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:9.0) Gecko/20111222 Thunderbird/9.0.1",
 		UserAgent{
-			Browser{BrowserFirefox, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 7, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 7, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_2) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.75 Safari/535.7",
 		UserAgent{
-			Browser{BrowserChrome, Version{16, 0, 912}, Version{16, 0, 912}}, OS{PlatformMac, OSMacOSX, Version{10, 7, 2}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{16, 0, 912}, Version{16, 0, 912}}, OS{PlatformMac, OSMacOSX, Version{10, 7, 2}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8) AppleWebKit/535.18.5 (KHTML, like Gecko) Version/5.2 Safari/535.18.5",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8) AppleWebKit/535.18.5 (KHTML, like Gecko) Version/5.2 Safari/535.18.5",
 		UserAgent{
-			Browser{BrowserSafari, Version{5, 2, 0}, Version{5, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 8, 0}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{5, 2, 0}, Version{5, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 8, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_8; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.249.0 Safari/532.5",
+	{
+		"Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_8; en-US) AppleWebKit/532.5 (KHTML, like Gecko) Chrome/4.0.249.0 Safari/532.5",
 		UserAgent{
-			Browser{BrowserChrome, Version{4, 0, 249}, Version{4, 0, 249}}, OS{PlatformMac, OSMacOSX, Version{10, 8, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{4, 0, 249}, Version{4, 0, 249}}, OS{PlatformMac, OSMacOSX, Version{10, 8, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.35.1 (KHTML, like Gecko) Version/6.1 Safari/537.35.1",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9) AppleWebKit/537.35.1 (KHTML, like Gecko) Version/6.1 Safari/537.35.1",
 		UserAgent{
-			Browser{BrowserSafari, Version{6, 1, 0}, Version{6, 1, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 9, 0}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{6, 1, 0}, Version{6, 1, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 9, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.34.48 (KHTML, like Gecko) Version/8.0 Safari/538.35.8",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.34.48 (KHTML, like Gecko) Version/8.0 Safari/538.35.8",
 		UserAgent{
-			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 0}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.32 (KHTML, like Gecko) Version/7.1 Safari/538.4",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10) AppleWebKit/538.32 (KHTML, like Gecko) Version/7.1 Safari/538.4",
 		UserAgent{
-			Browser{BrowserSafari, Version{7, 1, 0}, Version{7, 1, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 0}}, DeviceComputer}},
+			Browser{BrowserSafari, Version{7, 1, 0}, Version{7, 1, 0}}, OS{PlatformMac, OSMacOSX, Version{10, 10, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Opera/9.80 (S60; SymbOS; Opera Mobi/352; U; de) Presto/2.4.15 Version/10.00",
+	{
+		"Opera/9.80 (S60; SymbOS; Opera Mobi/352; U; de) Presto/2.4.15 Version/10.00",
 		UserAgent{
-			Browser{BrowserOpera, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserOpera, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Opera/9.80 (S60; SymbOS; Opera Mobi/352; U; de) Presto/2.4.15 Version/10.00",
+	{
+		"Opera/9.80 (S60; SymbOS; Opera Mobi/352; U; de) Presto/2.4.15 Version/10.00",
 		UserAgent{
-			Browser{BrowserOpera, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserOpera, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
 	// TODO: support OneBrowser? https://play.google.com/store/apps/details?id=com.tencent.ibibo.mtt&hl=en_GB
 	//{"OneBrowser/3.1 (NokiaN70-1/5.0638.3.0.1)",
 	//	UserAgent{
 	//		Browser{BrowserUnknown, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformUnknown, OSUnknown, Version{0, 0, 0}}, DevicePhone}},
 
-	{"Mozilla/5.0 (webOS/1.0; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.0",
+	{
+		"Mozilla/5.0 (webOS/1.0; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.0",
 		UserAgent{
-			Browser{BrowserSafari, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (webOS/1.4.1.1; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.0",
+	{
+		"Mozilla/5.0 (webOS/1.4.1.1; U; en-US) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pre/1.0",
 		UserAgent{
-			Browser{BrowserSafari, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DevicePhone}},
+			Browser{BrowserSafari, Version{1, 0, 0}, Version{1, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.0; U; de-DE) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.70 Safari/534.6 TouchPad/1.0",
+	{
+		"Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.0; U; de-DE) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/233.70 Safari/534.6 TouchPad/1.0",
 		UserAgent{
-			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.2; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.40.1 Safari/534.6 TouchPad/1.0",
+	{
+		"Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.2; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.40.1 Safari/534.6 TouchPad/1.0",
 		UserAgent{
-			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DeviceTablet}},
+			Browser{BrowserSafari, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformLinux, OSWebOS, Version{0, 0, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Opera/9.30 (Nintendo Wii; U; ; 2047-7; fr)",
+	{
+		"Opera/9.30 (Nintendo Wii; U; ; 2047-7; fr)",
 		UserAgent{
-			Browser{BrowserOpera, Version{9, 30, 0}, Version{9, 30, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole}},
+			Browser{BrowserOpera, Version{9, 30, 0}, Version{9, 30, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole,
+		},
+	},
 
-	{"Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US",
+	{
+		"Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US",
 		UserAgent{
-			Browser{BrowserNintendo, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole}},
+			Browser{BrowserNintendo, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole,
+		},
+	},
 
-	{"Mozilla/5.0 (Nintendo WiiU) AppleWebKit/536.28 (KHTML, like Gecko) NX/3.0.3.12.6 NintendoBrowser/2.0.0.9362.US",
+	{
+		"Mozilla/5.0 (Nintendo WiiU) AppleWebKit/536.28 (KHTML, like Gecko) NX/3.0.3.12.6 NintendoBrowser/2.0.0.9362.US",
 		UserAgent{
-			Browser{BrowserNintendo, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole}},
+			Browser{BrowserNintendo, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformNintendo, OSNintendo, Version{0, 0, 0}}, DeviceConsole,
+		},
+	},
 
 	// TODO fails to get opera first -- but is this a real UA string or an uncommon spoof?
 	//{"Mozilla/4.0 (compatible; MSIE 5.0; Windows 2000) Opera 6.0 [en]",
 	//	UserAgent{
 	//		Browser{BrowserOpera, Version{5, 0, 0}, Version{5, 0, 0}}, OS{PlatformWindows, OSWindows, Version{4, 0, 0}}, DeviceComputer}},
 
-	{"Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0; SV1; .NET CLR 1.1.4322; .NET CLR 1.0.3705; .NET CLR 2.0.50727)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0; SV1; .NET CLR 1.1.4322; .NET CLR 1.0.3705; .NET CLR 2.0.50727)",
 		UserAgent{
-			Browser{BrowserIE, Version{5, 0, 1}, Version{5, 0, 1}}, OS{PlatformWindows, OSWindows, Version{5, 0, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{5, 0, 1}, Version{5, 0, 1}}, OS{PlatformWindows, OSWindows, Version{5, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0; SV1; .NET CLR 1.1.4322; .NET CLR 1.0.3705; .NET CLR 2.0.50727)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 5.01; Windows NT 5.0; SV1; .NET CLR 1.1.4322; .NET CLR 1.0.3705; .NET CLR 2.0.50727)",
 		UserAgent{
-			Browser{BrowserIE, Version{5, 0, 1}, Version{5, 0, 1}}, OS{PlatformWindows, OSWindows, Version{5, 0, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{5, 0, 1}, Version{5, 0, 1}}, OS{PlatformWindows, OSWindows, Version{5, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; GTB6.4; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 1.1.4322)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; GTB6.4; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; OfficeLiveConnector.1.3; OfficeLivePatch.0.0; .NET CLR 1.1.4322)",
 		UserAgent{
-			Browser{BrowserIE, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows; U; Windows NT 6.1; sk; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7",
+	{
+		"Mozilla/5.0 (Windows; U; Windows NT 6.1; sk; rv:1.9.1.7) Gecko/20091221 Firefox/3.5.7",
 		UserAgent{
-			Browser{BrowserFirefox, Version{3, 5, 7}, Version{3, 5, 7}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{3, 5, 7}, Version{3, 5, 7}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)",
+	{
+		"Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0)",
 		UserAgent{
-			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/536.5 (KHTML, like Gecko) YaBrowser/1.0.1084.5402 Chrome/19.0.1084.5402 Safari/536.5",
+	{
+		"Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/536.5 (KHTML, like Gecko) YaBrowser/1.0.1084.5402 Chrome/19.0.1084.5402 Safari/536.5",
 		UserAgent{
-			Browser{BrowserYandex, Version{1, 0, 1084}, Version{1, 0, 1084}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer}},
+			Browser{BrowserYandex, Version{1, 0, 1084}, Version{1, 0, 1084}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.15 (KHTML, like Gecko) Chrome/24.0.1295.0 Safari/537.15",
+	{
+		"Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.15 (KHTML, like Gecko) Chrome/24.0.1295.0 Safari/537.15",
 		UserAgent{
-			Browser{BrowserChrome, Version{24, 0, 1295}, Version{24, 0, 1295}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer}},
+			Browser{BrowserChrome, Version{24, 0, 1295}, Version{24, 0, 1295}}, OS{PlatformWindows, OSWindows, Version{6, 2, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko",
+	{
+		"Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko",
 		UserAgent{
-			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceTablet}},
+			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko",
+	{
+		"Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko",
 		UserAgent{
-			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SLCC1; .NET CLR 2.0.50727; .NET CLR 1.1.4322; InfoPath.2; .NET CLR 3.5.21022; .NET CLR 3.5.30729; MS-RTC LM 8; OfficeLiveConnector.1.4; OfficeLivePatch.1.3; .NET CLR 3.0.30729)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; SLCC1; .NET CLR 2.0.50727; .NET CLR 1.1.4322; InfoPath.2; .NET CLR 3.5.21022; .NET CLR 3.5.30729; MS-RTC LM 8; OfficeLiveConnector.1.4; OfficeLivePatch.1.3; .NET CLR 3.0.30729)",
 		UserAgent{
-			Browser{BrowserIE, Version{8, 0, 0}, Version{8, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 0, 0}},
-			DeviceComputer}},
+			Browser{BrowserIE, Version{8, 0, 0}, Version{8, 0, 0}},
+			OS{PlatformWindows, OSWindows, Version{6, 0, 0}},
+			DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows; U; Windows NT 5.1; cs; rv:1.9.1.8) Gecko/20100202 Firefox/3.5.8",
+	{
+		"Mozilla/5.0 (Windows; U; Windows NT 5.1; cs; rv:1.9.1.8) Gecko/20100202 Firefox/3.5.8",
 		UserAgent{
-			Browser{BrowserFirefox, Version{3, 5, 8}, Version{3, 5, 8}}, OS{PlatformWindows, OSWindows, Version{5, 1, 0}}, DeviceComputer}},
+			Browser{BrowserFirefox, Version{3, 5, 8}, Version{3, 5, 8}}, OS{PlatformWindows, OSWindows, Version{5, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; )",
+	{
+		"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; )",
 		UserAgent{
-			Browser{BrowserIE, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformWindows, OSWindows, Version{5, 1, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformWindows, OSWindows, Version{5, 1, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5.3.5)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5.3.5)",
 		UserAgent{
-			Browser{BrowserIE, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{6, 5, 3}}, DevicePhone}},
+			Browser{BrowserIE, Version{6, 0, 0}, Version{6, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{6, 5, 3}}, DevicePhone,
+		},
+	},
 
 	// desktop mode for Windows Phone 7
-	{"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; XBLWP7; ZuneWP7)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; XBLWP7; ZuneWP7)",
 		UserAgent{
-			Browser{BrowserIE, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer}},
+			Browser{BrowserIE, Version{7, 0, 0}, Version{7, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 1, 0}}, DeviceComputer,
+		},
+	},
 
 	// mobile mode for Windows Phone 7
-	{"Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; T8788)",
+	{
+		"Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; T8788)",
 		UserAgent{
-			Browser{BrowserIE, Version{7, 1, 0}, Version{7, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{7, 0, 0}}, DevicePhone}},
+			Browser{BrowserIE, Version{7, 1, 0}, Version{7, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{7, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)",
+	{
+		"Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0)",
 		UserAgent{
-			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{7, 5, 0}}, DevicePhone}},
+			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{7, 5, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)",
+	{
+		"Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)",
 		UserAgent{
-			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 0, 0}}, DevicePhone}},
+			Browser{BrowserIE, Version{10, 0, 0}, Version{10, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 0, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch IEMobile/11.0; HTC; Windows Phone 8S by HTC) like Gecko",
+	{
+		"Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch IEMobile/11.0; HTC; Windows Phone 8S by HTC) like Gecko",
 		UserAgent{
-			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 1, 0}}, DevicePhone}},
+			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 1, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch IEMobile/11.0; NOKIA; 909) like Gecko",
+	{
+		"Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch IEMobile/11.0; NOKIA; 909) like Gecko",
 		UserAgent{
-			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 1, 0}}, DevicePhone}},
+			Browser{BrowserIE, Version{11, 0, 0}, Version{11, 0, 0}}, OS{PlatformWindowsPhone, OSWindowsPhone, Version{8, 1, 0}}, DevicePhone,
+		},
+	},
 
-	{"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)",
+	{
+		"Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)",
 		UserAgent{
-			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformXbox, OSXbox, Version{6, 1, 0}}, DeviceConsole}},
-	{"Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/42.0 CoRom/36.0.1985.144 Chrome/36.0.1985.144 Safari/537.36",
+			Browser{BrowserIE, Version{9, 0, 0}, Version{9, 0, 0}}, OS{PlatformXbox, OSXbox, Version{6, 1, 0}}, DeviceConsole,
+		},
+	},
+	{
+		"Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/42.0 CoRom/36.0.1985.144 Chrome/36.0.1985.144 Safari/537.36",
 		UserAgent{
-			Browser{BrowserCocCoc, Version{42, 0, 0}, Version{42, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceComputer}},
-	{"Mozilla/5.0 (compatible; coccocbot/1.0; +http://help.coccoc.com/searchengine)",
+			Browser{BrowserCocCoc, Version{42, 0, 0}, Version{42, 0, 0}}, OS{PlatformWindows, OSWindows, Version{6, 3, 0}}, DeviceComputer,
+		},
+	},
+	{
+		"Mozilla/5.0 (compatible; coccocbot/1.0; +http://help.coccoc.com/searchengine)",
 		UserAgent{
-			Browser{BrowserCocCocBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer}},
+			Browser{BrowserCocCocBot, Version{0, 0, 0}, Version{0, 0, 0}}, OS{PlatformBot, OSBot, Version{0, 0, 0}}, DeviceComputer,
+		},
+	},
 
-	{"Mozilla/5.0 (Linux; Android 4.4.4; SM-T560 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36",
+	{
+		"Mozilla/5.0 (Linux; Android 4.4.4; SM-T560 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{63, 0, 3239}, Version{63, 0, 3239}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 4}}, DeviceTablet}},
-	{"Mozilla/5.0 (Linux; Android 5.1.1; KFSUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/70.4.2 like Chrome/70.0.3538.80 Safari/537.36",
+			Browser{BrowserChrome, Version{63, 0, 3239}, Version{63, 0, 3239}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 4}}, DeviceTablet,
+		},
+	},
+	{
+		"Mozilla/5.0 (Linux; Android 5.1.1; KFSUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/70.4.2 like Chrome/70.0.3538.80 Safari/537.36",
 		UserAgent{
-			Browser{BrowserSilk, Version{70, 4, 2}, Version{70, 4, 2}}, OS{PlatformLinux, OSAndroid, Version{5, 1, 1}}, DeviceTablet}},
-	{"Mozilla/5.0 (Linux; Android 4.4.2; T1-701u Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Safari/537.36",
+			Browser{BrowserSilk, Version{70, 4, 2}, Version{70, 4, 2}}, OS{PlatformLinux, OSAndroid, Version{5, 1, 1}}, DeviceTablet,
+		},
+	},
+	{
+		"Mozilla/5.0 (Linux; Android 4.4.2; T1-701u Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{64, 0, 3282}, Version{64, 0, 3282}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 2}}, DeviceTablet}},
-	{"Mozilla/5.0 (Linux; Android 4.4.2; Lenovo TAB 2 A7-30F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.84 Safari/537.36",
+			Browser{BrowserChrome, Version{64, 0, 3282}, Version{64, 0, 3282}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 2}}, DeviceTablet,
+		},
+	},
+	{
+		"Mozilla/5.0 (Linux; Android 4.4.2; Lenovo TAB 2 A7-30F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.84 Safari/537.36",
 		UserAgent{
-			Browser{BrowserChrome, Version{45, 0, 2454}, Version{45, 0, 2454}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 2}}, DeviceTablet}},
+			Browser{BrowserChrome, Version{45, 0, 2454}, Version{45, 0, 2454}}, OS{PlatformLinux, OSAndroid, Version{4, 4, 2}}, DeviceTablet,
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko)",
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_6) AppleWebKit/605.1.15 (KHTML, like Gecko)",
 		UserAgent{
 			Browser{BrowserWebkit, Version{605, 1, 15}, Version{605, 1, 15}}, OS{PlatformMac, OSMacOSX, Version{10, 15, 6}}, DeviceComputer,
-		}},
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)",
+		},
+	},
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko)",
 		UserAgent{
 			Browser{BrowserWebkit, Version{605, 1, 15}, Version{605, 1, 15}}, OS{PlatformMac, OSMacOSX, Version{10, 15, 7}}, DeviceComputer,
-		}},
+		},
+	},
 
-	{"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/92.0.4512.0 Safari/537.36 CloudWatchSynthetics/arn:aws:synthetics:us-west-2:891067072053:canary:ai-production-sa",
+	{
+		"Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/92.0.4512.0 Safari/537.36 CloudWatchSynthetics/arn:aws:synthetics:us-west-2:891067072053:canary:ai-production-sa",
 		UserAgent{
 			Browser{BrowserChrome, Version{92, 0, 4512}, Version{92, 0, 4512}}, OS{PlatformLinux, OSLinux, Version{0, 0, 0}}, DeviceComputer,
-		}},
+		},
+	},
 
-	{"Mozilla/5.0 (Macintosh Intel Mac OS X 12_6_1) Gecko/20100101 Firefox/107.0", UserAgent{
-		Browser{BrowserFirefox, Version{107, 0, 0}, Version{107, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{12, 6, 1}}, DeviceComputer},
+	{
+		"Mozilla/5.0 (Macintosh Intel Mac OS X 12_6_1) Gecko/20100101 Firefox/107.0", UserAgent{
+			Browser{BrowserFirefox, Version{107, 0, 0}, Version{107, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{12, 6, 1}}, DeviceComputer,
+		},
 	},
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36", UserAgent{
-		Browser{BrowserChrome, Version{110, 0, 0}, Version{110, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer},
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/110.0.0.0 Safari/537.36", UserAgent{
+			Browser{BrowserChrome, Version{110, 0, 0}, Version{110, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer,
+		},
 	},
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36", UserAgent{
-		Browser{BrowserChrome, Version{111, 0, 0}, Version{111, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer},
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36", UserAgent{
+			Browser{BrowserChrome, Version{111, 0, 0}, Version{111, 0, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer,
+		},
 	},
 	{
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36 Edg/109.0.1587.69", UserAgent{
-			Browser{BrowserEdge, Version{109, 0, 1587}, Version{109, 0, 1587}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer},
+			Browser{BrowserEdge, Version{109, 0, 1587}, Version{109, 0, 1587}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer,
+		},
 	},
-	{"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36 Edg/110.0.1587.69", UserAgent{
-		Browser{BrowserEdge, Version{110, 0, 1587}, Version{110, 0, 1587}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer},
-	}, {
+	{
+		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36 Edg/110.0.1587.69", UserAgent{
+			Browser{BrowserEdge, Version{110, 0, 1587}, Version{110, 0, 1587}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer,
+		},
+	},
+	{
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/537.36 (KHTML, like Gecko) Gecko/20100101 Firefox/111.0", UserAgent{
-			Browser{BrowserWebkit, Version{537, 36, 0}, Version{537, 36, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer},
-	}, {
+			Browser{BrowserWebkit, Version{537, 36, 0}, Version{537, 36, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer,
+		},
+	},
+	{
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.2 Safari/605.1.15", UserAgent{
-			Browser{BrowserSafari, Version{16, 2, 0}, Version{16, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer},
+			Browser{BrowserSafari, Version{16, 2, 0}, Version{16, 2, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer,
+		},
 	},
 	{
 		"Mozilla/5.0 (Macintosh; Intel Mac OS X 13_2_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.3 Safari/605.1.15", UserAgent{
-			Browser{BrowserSafari, Version{16, 3, 0}, Version{16, 3, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer},
-	}, {
+			Browser{BrowserSafari, Version{16, 3, 0}, Version{16, 3, 0}}, OS{PlatformMac, OSMacOSX, Version{13, 2, 1}}, DeviceComputer,
+		},
+	},
+	{
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36", UserAgent{
-			Browser{BrowserChrome, Version{111, 0, 0}, Version{111, 0, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer},
-	}, {
+			Browser{BrowserChrome, Version{111, 0, 0}, Version{111, 0, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer,
+		},
+	},
+	{
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:111.0) Gecko/20100101 Firefox/110.0", UserAgent{
-			Browser{BrowserFirefox, Version{110, 0, 0}, Version{110, 0, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer},
-	}, {
+			Browser{BrowserFirefox, Version{110, 0, 0}, Version{110, 0, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer,
+		},
+	},
+	{
 		"Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:111.0) Gecko/20100101 Firefox/111.0", UserAgent{
-			Browser{BrowserFirefox, Version{111, 0, 0}, Version{111, 0, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer},
+			Browser{BrowserFirefox, Version{111, 0, 0}, Version{111, 0, 0}}, OS{PlatformWindows, OSWindows, Version{10, 0, 0}}, DeviceComputer,
+		},
 	},
 }
 
@@ -1169,6 +1711,139 @@ func TestStringTrimPrefix(t *testing.T) {
 			s := tc.f()
 			if tc.expected != s {
 				t.Fatalf("Expected %q, got %q", tc.expected, s)
+			}
+		})
+	}
+}
+
+// make sure generated code is in sync with current enum values
+
+func TestBrowserName_StringTrimPrefix(t *testing.T) {
+	tests := []struct {
+		browser BrowserName
+		want    string
+	}{
+		{browser: BrowserUnknown, want: "Unknown"},
+		{browser: BrowserChrome, want: "Chrome"},
+		{browser: BrowserIE, want: "IE"},
+		{browser: BrowserEdge, want: "Edge"},
+		{browser: BrowserSafari, want: "Safari"},
+		{browser: BrowserFirefox, want: "Firefox"},
+		{browser: BrowserAndroid, want: "Android"},
+		{browser: BrowserOpera, want: "Opera"},
+		{browser: BrowserBlackberry, want: "Blackberry"},
+		{browser: BrowserUCBrowser, want: "UCBrowser"},
+		{browser: BrowserSilk, want: "Silk"},
+		{browser: BrowserNokia, want: "Nokia"},
+		{browser: BrowserNetFront, want: "NetFront"},
+		{browser: BrowserQQ, want: "QQ"},
+		{browser: BrowserMaxthon, want: "Maxthon"},
+		{browser: BrowserSogouExplorer, want: "SogouExplorer"},
+		{browser: BrowserSpotify, want: "Spotify"},
+		{browser: BrowserWebkit, want: "Webkit"},
+		{browser: BrowserNintendo, want: "Nintendo"},
+		{browser: BrowserSamsung, want: "Samsung"},
+		{browser: BrowserYandex, want: "Yandex"},
+		{browser: BrowserCocCoc, want: "CocCoc"},
+		{browser: BrowserBot, want: "Bot"},
+		{browser: BrowserAppleBot, want: "AppleBot"},
+		{browser: BrowserBaiduBot, want: "BaiduBot"},
+		{browser: BrowserBingBot, want: "BingBot"},
+		{browser: BrowserDuckDuckGoBot, want: "DuckDuckGoBot"},
+		{browser: BrowserFacebookBot, want: "FacebookBot"},
+		{browser: BrowserGoogleBot, want: "GoogleBot"},
+		{browser: BrowserLinkedInBot, want: "LinkedInBot"},
+		{browser: BrowserMsnBot, want: "MsnBot"},
+		{browser: BrowserPingdomBot, want: "PingdomBot"},
+		{browser: BrowserTwitterBot, want: "TwitterBot"},
+		{browser: BrowserYandexBot, want: "YandexBot"},
+		{browser: BrowserCocCocBot, want: "CocCocBot"},
+		{browser: BrowserYahooBot, want: "YahooBot"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.browser), func(t *testing.T) {
+			if got := tt.browser.StringTrimPrefix(); got != tt.want {
+				t.Errorf("BrowserName.StringTrimPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDeviceType_StringTrimPrefix(t *testing.T) {
+	tests := []struct {
+		device DeviceType
+		want   string
+	}{
+		{device: DeviceUnknown, want: "Unknown"},
+		{device: DeviceComputer, want: "Computer"},
+		{device: DeviceTablet, want: "Tablet"},
+		{device: DevicePhone, want: "Phone"},
+		{device: DeviceConsole, want: "Console"},
+		{device: DeviceWearable, want: "Wearable"},
+		{device: DeviceTV, want: "TV"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.device), func(t *testing.T) {
+			if got := tt.device.StringTrimPrefix(); got != tt.want {
+				t.Errorf("DeviceType.StringTrimPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOSName_StringTrimPrefix(t *testing.T) {
+	tests := []struct {
+		os   OSName
+		want string
+	}{
+		{os: OSUnknown, want: "Unknown"},
+		{os: OSWindowsPhone, want: "WindowsPhone"},
+		{os: OSWindows, want: "Windows"},
+		{os: OSMacOSX, want: "MacOSX"},
+		{os: OSiOS, want: "iOS"},
+		{os: OSAndroid, want: "Android"},
+		{os: OSBlackberry, want: "Blackberry"},
+		{os: OSChromeOS, want: "ChromeOS"},
+		{os: OSKindle, want: "Kindle"},
+		{os: OSWebOS, want: "WebOS"},
+		{os: OSLinux, want: "Linux"},
+		{os: OSPlaystation, want: "Playstation"},
+		{os: OSXbox, want: "Xbox"},
+		{os: OSNintendo, want: "Nintendo"},
+		{os: OSBot, want: "Bot"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.os), func(t *testing.T) {
+			if got := tt.os.StringTrimPrefix(); got != tt.want {
+				t.Errorf("OSName.StringTrimPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlatform_StringTrimPrefix(t *testing.T) {
+	tests := []struct {
+		platform Platform
+		want     string
+	}{
+		{platform: PlatformUnknown, want: "Unknown"},
+		{platform: PlatformWindows, want: "Windows"},
+		{platform: PlatformMac, want: "Mac"},
+		{platform: PlatformLinux, want: "Linux"},
+		{platform: PlatformiPad, want: "iPad"},
+		{platform: PlatformiPhone, want: "iPhone"},
+		{platform: PlatformiPod, want: "iPod"},
+		{platform: PlatformBlackberry, want: "Blackberry"},
+		{platform: PlatformWindowsPhone, want: "WindowsPhone"},
+		{platform: PlatformPlaystation, want: "Playstation"},
+		{platform: PlatformXbox, want: "Xbox"},
+		{platform: PlatformNintendo, want: "Nintendo"},
+		{platform: PlatformBot, want: "Bot"},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("%d", tt.platform), func(t *testing.T) {
+			if got := tt.platform.StringTrimPrefix(); got != tt.want {
+				t.Errorf("Platform.StringTrimPrefix() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Currently, string values of enums seem to be outdated.
For example, if you call

```go
BrowserOpera.String()
```

it returns `BrowserBlackberry` instead of expected `BrowserOpera`.

This pull request provides re-generated enums and additional unit tests for enum string values to prevent this kind of issues in the future